### PR TITLE
fix reason syntax regression

### DIFF
--- a/src/vendor/esy-lib/Fs.re
+++ b/src/vendor/esy-lib/Fs.re
@@ -134,8 +134,8 @@ let lstat = (path: Path.t) => {
 
 let isDir = (path: Path.t) =>
   switch%lwt (stat(path)) {
-  | Ok({st_kind: Unix.S_DIR, _}) => RunAsync.return(true)
-  | Ok({st_kind: _, _}) => RunAsync.return(false)
+  | Ok({ st_kind: Unix.S_DIR, _ }) => RunAsync.return(true)
+  | Ok({ st_kind: _, _ }) => RunAsync.return(false)
   | Error(_) => RunAsync.return(false)
   };
 
@@ -581,7 +581,8 @@ let symlink = (~force=false, ~src, dst) => {
   | Ok () => return()
   | Error(Unix.EEXIST) when force =>
     /* try rm path but ignore errors */
-    let%lwt _: Run.t(unit) = rmPath(dst);
+    let%lwt rmPathResult = rmPath(dst);
+    let () = (rmPathResult: Run.t(unit)) |> ignore;
     switch%lwt (symlink'(src, dst)) {
     | Ok () => return()
     | Error(err) => mkError(err)
@@ -602,7 +603,7 @@ let realpath = path => {
 
   let isSymlinkAndExists = path =>
     switch%lwt (lstat(path)) {
-    | Ok({Unix.st_kind: Unix.S_LNK, _}) => return(true)
+    | Ok({ Unix.st_kind: Unix.S_LNK, _ }) => return(true)
     | _ => return(false)
     };
 


### PR DESCRIPTION
Before, with `reason.3.15.0`, `ppx_let.v0.17.0`:

```ocaml
let __ppx_lwt_0 = rmPath dst in
Lwt.backtrace_bind
  (fun exn -> try Lwt.reraise exn with | exn -> exn) __ppx_lwt_0
  (fun (_ : unit Run.t) ->
    Lwt.try_bind (fun () -> symlink' src dst)
      (function
        | ((Ok (()))[@explicit_arity ]) -> return ()
        | ((Error (err))[@explicit_arity ]) -> mkError err)
      (function | exn -> Lwt.reraise exn))
```

Now, with `reason.3.17.0` (or `reason.3.16.0`), `ppx_let.v0.17.1`:

```ocaml
let __ppx_lwt_0 : unit Run.t = rmPath dst in
Lwt.backtrace_bind
  (fun exn -> try Lwt.reraise exn with | exn -> exn)
  __ppx_lwt_0
  (fun _ ->
     Lwt.try_bind (fun () -> symlink' src dst)
       (function
        | ((Ok (()))[@explicit_arity ]) -> return ()
        | ((Error (err))[@explicit_arity ]) -> mkError err)
       (function | exn -> Lwt.reraise exn))
```